### PR TITLE
Update SupportedArch.alpine

### DIFF
--- a/SupportedArch.alpine
+++ b/SupportedArch.alpine
@@ -1,1 +1,1 @@
-linux/arm64/v8,linux/amd64,linux/arm/v6,linux/arm/v7,linux/386,linux/s390x,linux/ppc64le
+linux/arm64/v8,linux/amd64,linux/arm/v6,linux/arm/v7,linux/386,linux/s390x


### PR DESCRIPTION
alpine no longer supports `linux/ppc64le`